### PR TITLE
Set recipient to atoms in addScipionAttribute()

### DIFF
--- a/mapq/protocols/protocol_mapq.py
+++ b/mapq/protocols/protocol_mapq.py
@@ -141,7 +141,7 @@ class ProtMapQ(ProtAnalysis3D):
                          for atom in ASH.getStructure().get_atoms()}
             inpAS = toCIF(pdbFile, outStructFileName)
             cifDic = ASH.readLowLevel(inpAS)
-            cifDic = addScipionAttribute(cifDic, mapQ_dict, self._ATTRNAME)
+            cifDic = addScipionAttribute(cifDic, mapQ_dict, self._ATTRNAME, recipient = 'atoms')
             ASH._writeLowLevel(outStructFileName, cifDic)
 
             outAS = AtomStruct()


### PR DESCRIPTION
Set recipient param to "atoms" when creating scipion attribute with addScipionAttribute to avoid missing data.