### PR TITLE
Update mapq version

### DIFF
--- a/mapq/__init__.py
+++ b/mapq/__init__.py
@@ -137,10 +137,9 @@ class Plugin(pwem.Plugin):
                              "printf './chimera\\nno\\n\\n' | ../chimera-%s-linux_x86_64.bin"
                              % (version, version),
                              "chimera"))
-
-        chimera_cmds.append(('wget -c https://github.com/gregdp/mapq/raw/master/download/mapq_1_8_2.zip',
-                             'mapq_1_8_2.zip'))
-        chimera_cmds.append(('unzip mapq_1_8_2.zip', "mapq"))
+        chimera_cmds.append(('wget -c https://github.com/gregdp/mapq/raw/master/download/mapq_v2.9.7.zip',
+                             'mapq_v2.9.7.zip'))
+        chimera_cmds.append(('unzip mapq_v2.9.7.zip', "mapq"))
         chimera_cmds.append(("cd mapq && python install.py ../chimera &&"
                              "touch ../mapq_installed", "mapq_installed"))
         chimera_cmds.append(('wget -c https://github.com/gregdp/mapq/raw/master/data/QScore_Apoferritin_Tutorial.zip',

--- a/mapq/__init__.py
+++ b/mapq/__init__.py
@@ -31,6 +31,7 @@ import pwem
 import pyworkflow.utils as pwutils
 
 import mapq.constants as mapqConst
+import glob
 
 __version__ = "1.0.0"
 _logo = "mapq_logo.png"
@@ -74,6 +75,18 @@ class Plugin(pwem.Plugin):
     @classmethod
     def getChimeraProgram(cls):
         return cls.getChimeraPath() + "/bin/chimera"
+
+    @classmethod
+    def getChimeraXPath(cls):
+        em_folder = os.path.dirname(os.path.dirname(str(cls.getHome('chimera'))))
+        print(f'\nem folder folder: {em_folder}\n')
+        chimerax_folder = glob.glob(os.path.join(em_folder, 'chimerax*'))[0]  # Get the first match
+        print(f'\nChimerax folder: {chimerax_folder}\n')
+        return chimerax_folder
+
+    @classmethod
+    def getChimeraXProgram(cls):
+        return cls.getChimeraXPath() + "/bin/ChimeraX"
 
     @classmethod
     def getMapQProgram(cls):

--- a/mapq/__init__.py
+++ b/mapq/__init__.py
@@ -79,9 +79,7 @@ class Plugin(pwem.Plugin):
     @classmethod
     def getChimeraXPath(cls):
         em_folder = os.path.dirname(os.path.dirname(str(cls.getHome('chimera'))))
-        print(f'\nem folder folder: {em_folder}\n')
         chimerax_folder = glob.glob(os.path.join(em_folder, 'chimerax*'))[0]  # Get the first match
-        print(f'\nChimerax folder: {chimerax_folder}\n')
         return chimerax_folder
 
     @classmethod

--- a/mapq/__init__.py
+++ b/mapq/__init__.py
@@ -78,7 +78,7 @@ class Plugin(pwem.Plugin):
 
     @classmethod
     def getChimeraXPath(cls):
-        em_folder = os.path.dirname(os.path.dirname(str(cls.getHome('chimera'))))
+        em_folder = pwem.Config.EM_ROOT
         chimerax_folder = glob.glob(os.path.join(em_folder, 'chimerax*'))[0]  # Get the first match
         return chimerax_folder
 

--- a/mapq/protocols/protocol_mapq.py
+++ b/mapq/protocols/protocol_mapq.py
@@ -26,6 +26,7 @@
 
 from os.path import abspath
 import numpy as np
+import pandas as pd
 
 from pwem.convert import toCIF, Ccp4Header
 from pwem.convert.atom_struct import toPdb, AtomicStructHandler, addScipionAttribute
@@ -139,9 +140,9 @@ class ProtMapQ(ProtAnalysis3D):
             pdbFile = pdb.get().getFileName()
             baseName = pwutils.removeBaseExt(pdbFile)
             outStructFileName = outStructFileBase.format(baseName)
-            ASH.read(self._getExtraPath(baseName + "__Q__map.pdb"))
-            mapQ_dict = {'{}:{}'.format(atom.full_id[2], atom.serial_number): str(round(atom.bfactor, 4))
-                         for atom in ASH.getStructure().get_atoms()}
+            mapq_pdb = self._getExtraPath(baseName + ".pdb__Q__map.mrc.pdb")
+            ASH.read(mapq_pdb)
+            mapQ_dict = self.createMapQDict(mapq_pdb)
             inpAS = toCIF(pdbFile, outStructFileName)
             cifDic = ASH.readLowLevel(inpAS)
             cifDic = addScipionAttribute(cifDic, mapQ_dict, self._ATTRNAME, recipient = 'atoms')
@@ -162,6 +163,21 @@ class ProtMapQ(ProtAnalysis3D):
             coords = atom.get_coord()
             atom.coord = coords + np.asarray(newOrigin) - np.asarray(centerMass)
 
+    def createMapQDict(self, mapq_pdb):
+        colspecs = [(0, 6), (6, 11), (12, 16), (16, 17), (17, 20), (21, 22), (22, 26), (26, 27),
+                    (30, 38), (38, 46), (46, 54), (54, 60), (60, 66), (76, 78), (78, 80)]
+        names = ['type', 'serial', 'name', 'altloc', 'resname', 'chainid', 'resseq',
+                 'icode', 'x', 'y', 'z', 'occupancy', 'Q_score', 'element', 'charge']
+
+        pdb = pd.read_fwf(mapq_pdb, names=names, colspecs=colspecs)
+        df_atoms = pdb[pdb[pdb.columns[0]].isin(['ATOM', 'HETATM'])]
+        df_atoms = df_atoms.reset_index(drop=True)
+
+        mapQ_dict = {
+            f"{row['chainid']}:{int(row['serial'])}": str(row['Q_score'])
+            for _, row in df_atoms.iterrows()
+        }
+        return mapQ_dict
 
     # --------------------------- INFO functions ------------------------------
     def _methods(self):

--- a/mapq/protocols/protocol_mapq.py
+++ b/mapq/protocols/protocol_mapq.py
@@ -87,28 +87,31 @@ class ProtMapQ(ProtAnalysis3D):
         Ccp4Header.fixFile(volFile, self.volOutFile, origin, sampling,
                            Ccp4Header.START)
 
+        self.cifOutFile = []
         self.pdbOutFile = []
         for pdb in self.pdbs:
-            pdbFile = pdb.get().getFileName()
-            baseName = pwutils.removeBaseExt(pdbFile)
+            cifFile = pdb.get().getFileName()
+            baseName = pwutils.removeBaseExt(cifFile)
+            self.cifOutFile.append(abspath(self._getExtraPath('%s.cif' % baseName)))  #############################
             self.pdbOutFile.append(abspath(self._getExtraPath('%s.pdb' % baseName)))
-            h = AtomicStructHandler()
-            h.read(pdbFile)
-            self.moveOriginTo([0, 0, 0], h)
-            h.writeAsPdb(self.pdbOutFile[-1])
 
+            h = AtomicStructHandler()
+            h.read(cifFile)
+            h.writeAsCif(self.cifOutFile[-1])
+
+            #### CHIMERAX
             if self.autoFit.get():
                 print("Fitting %s into map..." % baseName)
                 scriptFile = self._getTmpPath("fitting.py")
-                fhCmd = open(scriptFile, 'w')
-                fhCmd.write("import chimera\n")
-                fhCmd.write("from chimera import runCommand\n")
-                fhCmd.write("runCommand('open %s')\n" % self.pdbOutFile[-1])
-                fhCmd.write("runCommand('open %s')\n" % self.volOutFile)
-                fhCmd.write("runCommand('fitmap #0 #1')\n")
-                fhCmd.write("runCommand('write relative #1 #0 %s')\n" % self.pdbOutFile[-1])
+                with open(scriptFile, 'w') as fhCmd:  # Using 'with' ensures the file is properly closed
+                    fhCmd.write("from chimerax.core.commands import run\n")
+                    fhCmd.write("run(session, 'open %s')\n" % self.cifOutFile[-1])
+                    fhCmd.write("run(session, 'open %s')\n" % self.volOutFile)
+                    fhCmd.write("run(session, 'fitmap #1 inMap #2')\n")
+                    fhCmd.write("run(session, 'save %s models #1 relModel #2')\n" % self.pdbOutFile[-1])
+                    fhCmd.write("run(session, 'exit')\n")  # Ensure ChimeraX exits after running the script
                 args = "--nogui --script %s" % scriptFile
-                self.runJob(mapq.Plugin.getChimeraProgram(), args)
+                self.runJob(mapq.Plugin.getChimeraXProgram(), args)
 
     def computeQScoresStep(self):
         args = '%s %s ' % (mapq.Plugin.getChimeraPath(), self.volOutFile)

--- a/mapq/tests/test_protocols_mapq.py
+++ b/mapq/tests/test_protocols_mapq.py
@@ -30,6 +30,7 @@ import numpy as np
 
 from pwem.protocols import ProtImportPdb, ProtImportVolumes
 from pwem.convert.atom_struct import AtomicStructHandler
+import pwem.convert as emconv
 
 from pyworkflow.tests import BaseTest, setupTestProject
 
@@ -47,7 +48,7 @@ class TestMapQ(BaseTest):
         cls.map = join(mapq.Plugin.getHome('QScore_Apoferritin_Tutorial'), 'emd20026_prot.mrc')
 
     def runImportPDBs(cls, label):
-        """ Run an Import particles protocol. """
+        """ Run an Import atomic structure protocol. """
         protImport = cls.newProtocol(ProtImportPdb,
                                      inputPdbData=1,
                                      pdbFile=cls.pdb,
@@ -56,9 +57,11 @@ class TestMapQ(BaseTest):
         return protImport.outputPdb
 
     def runImportVolumes(cls, samplingRate, label):
-        """ Run an Import particles protocol. """
+        """ Run an Import volume protocol. """
+        ccp4header = emconv.Ccp4Header(cls.map, readHeader=True)
+        x, y, z = ccp4header.getOrigin(changeSign=True)
         protImport = cls.newProtocol(ProtImportVolumes,
-                                     filesPath=cls.map, samplingRate=samplingRate, objLabel=label, setOrigCoord=True, x=-117.0, y=-65.6500015258789, z=-101.399993896484)
+                                     filesPath=cls.map, samplingRate=samplingRate, objLabel=label, setOrigCoord=True, x=x, y=y, z=z)
         cls.launchProtocol(protImport)
         return protImport.outputVolume
 

--- a/mapq/tests/test_protocols_mapq.py
+++ b/mapq/tests/test_protocols_mapq.py
@@ -58,7 +58,7 @@ class TestMapQ(BaseTest):
     def runImportVolumes(cls, samplingRate, label):
         """ Run an Import particles protocol. """
         protImport = cls.newProtocol(ProtImportVolumes,
-                                     filesPath=cls.map, samplingRate=samplingRate, objLabel=label)
+                                     filesPath=cls.map, samplingRate=samplingRate, objLabel=label, setOrigCoord=True, x=-117.0, y=-65.6500015258789, z=-101.399993896484)
         cls.launchProtocol(protImport)
         return protImport.outputVolume
 
@@ -83,6 +83,6 @@ class TestMapQ(BaseTest):
             mapq_scores = [float(value) for attribute, value in zip(attributes, values)
                            if attribute == prot._ATTRNAME]
             mean_score = sum(mapq_scores) / len(mapq_scores)
-        self.assertEqual(round(mean_score, 4), -0.0052, "Unexpected score value: mean")
+        self.assertEqual(round(mean_score, 4), 0.8776, "Unexpected score value: mean")
 
         return prot


### PR DESCRIPTION
In this PR, the following changes are done:
- mapq version is updated
- now ChimeraX is used instead of Chimera when fitting model and map 
- move to origin code was removed to keep the origin fixed